### PR TITLE
Make the URL used to interact with the Investec Open API configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,23 @@ An NPM module to interact with Investec's Open API
 
 ## Set up client
 
-```
+```ts
 import { Client } from "investec-api";
-const client = await Client.create(id, secret, apiKey);
+const client = await Client.create(id, secret, apiKey, baseUrl?);
 ```
+
+| Param   | Required | Description                                                                                                                                      |
+| ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`      | `true`     | Your API key ID issued by Investec.                                                                                                              |
+| `secret`  | `true`     | The corresponding API key secret.                                                                                                                |
+| `apiKey`  | `true`     | The corresponding API key.                                                                                                                       |
+| `baseUrl` | `false`    | Optional base URL that will be used when interacting with the Investec Open API. If none is passed, then "https://openapi.investec.com" is used. |
 
 This creates an access token that the client will use to interact with the API.
 
 If you start to get errors about the token no longer being valid, simply call:
 
-```
+```ts
 await client.authenticate();
 ```
 
@@ -27,7 +34,7 @@ await client.authenticate();
 
 ### List accounts
 
-```
+```ts
 const accounts = await client.getAccounts("private" | "business" = "private");
 ```
 
@@ -39,13 +46,13 @@ On an `Account` object, you can:
 
 #### Get Balance
 
-```
+```ts
 const balance = await account.getBalance();
 ```
 
 #### Get transactions
 
-```
+```ts
 const transactions = await account.getTransactions({
   fromDate: string;
   toDate: string;
@@ -55,7 +62,7 @@ const transactions = await account.getTransactions({
 
 #### Transfer
 
-```
+```ts
 const transfer = await account.transfer([
   {
     account: Account;
@@ -68,7 +75,7 @@ const transfer = await account.transfer([
 
 #### Payments
 
-```
+```ts
 const payment = await account.pay([
   {
     beneficiary: InvestecBeneficiary;
@@ -83,13 +90,13 @@ const payment = await account.pay([
 
 ### List beneficiaries
 
-```
+```ts
 const beneficiaries = await client.getBeneficiaries();
 ```
 
 ### List beneficiary categories
 
-```
+```ts
 const beneficiaryCategories = await client.getBeneficiaryCategories();
 ```
 
@@ -97,25 +104,25 @@ const beneficiaryCategories = await client.getBeneficiaryCategories();
 
 ### List cards
 
-```
+```ts
 const cards = await client.getCards();
 ```
 
 ### Get Card countries
 
-```
+```ts
 const countries = await Card.getCountries();
 ```
 
 ### Get Card currencies
 
-```
+```ts
 const countries = await Card.getCurrencies();
 ```
 
 ### Get Card merchants
 
-```
+```ts
 const countries = await Card.getMerchants();
 ```
 
@@ -125,31 +132,31 @@ On a `Card` object, you can:
 
 #### Get Saved code
 
-```
+```ts
 const savedCode = await card.getSavedCode();
 ```
 
 #### Get published code
 
-```
+```ts
 const publishedCode = await card.getPublishedCode();
 ```
 
 #### Update saved code
 
-```
+```ts
 const updatedCode = await card.updateSavedCode(code: string);
 ```
 
 #### Publish saved code
 
-```
+```ts
 const publishedCode = await card.publishSavedCode(codeId: string);
 ```
 
 #### Simulate functions execution
 
-```
+```ts
 const execution = await card.simulateFunctionExecution({
   code: string;
   centsAmount: string;
@@ -162,26 +169,24 @@ const execution = await card.simulateFunctionExecution({
 
 #### Get previous executions
 
-```
+```ts
 const executions = await card.getExecutions();
 ```
 
 #### List environment variables
 
-```
+```ts
 const variables = await card.getEnvironmentVariables();
 ```
 
 #### Update environment variables
 
-```
+```ts
 const variables = await card.updateEnvironmentVariables({...});
 ```
 
 ## Investec Programmable Banking Docs
 
-You can read more about Investec's Programmable Banking here:  https://developer.investec.com/za/api-products/documentation/U0ElMjBQQiUyMEFjY291bnQlMjBJbmZvcm1hdGlvbg%3D%3D
+You can read more about Investec's Programmable Banking [here](https://developer.investec.com/za/api-products/documentation/U0ElMjBQQiUyMEFjY291bnQlMjBJbmZvcm1hdGlvbg%3D%3D).
 
-This library is merely an interface yo the above.
-
-
+This library is merely an interface to the above.

--- a/lib/investec/Account.ts
+++ b/lib/investec/Account.ts
@@ -1,11 +1,5 @@
 import { Client } from "..";
 import {
-  getAccountBalance,
-  getInvestecTransactionsForAccount,
-  postInvestecPayMultiple,
-  postInvestecTransferMultiple,
-} from "../util/investec";
-import {
   InvestecAccount,
   InvestecBeneficiary,
   InvestecPayment,
@@ -39,7 +33,7 @@ export class Account implements InvestecAccount {
     if (!this.client.token) {
       throw new Error("client is not set up");
     }
-    const balance = await getAccountBalance(
+    const balance = await this.client.ApiClient.getAccountBalance(
       this.client.token.access_token,
       this.accountId,
       this.realm
@@ -67,11 +61,12 @@ export class Account implements InvestecAccount {
     if (!this.client.token) {
       throw new Error("client is not set up");
     }
-    const transactions = await getInvestecTransactionsForAccount(
-      this.client.token.access_token,
-      { accountId: this.accountId, fromDate, toDate, transactionType },
-      this.realm
-    );
+    const transactions =
+      await this.client.ApiClient.getInvestecTransactionsForAccount(
+        this.client.token.access_token,
+        { accountId: this.accountId, fromDate, toDate, transactionType },
+        this.realm
+      );
     if (isResponseBad(transactions)) {
       throw new Error(
         `not ok response while getting transactions for account: ${{
@@ -94,19 +89,20 @@ export class Account implements InvestecAccount {
     if (!this.client.token) {
       throw new Error("client is not set up");
     }
-    const transferResponse = await postInvestecTransferMultiple(
-      this.client.token.access_token,
-      {
-        fromAccountId: this.accountId,
-        toAccounts: recipients.map((r) => ({
-          accountId: r.account.accountId,
-          amount: r.amount,
-          myReference: r.myReference,
-          theirReference: r.theirReference,
-        })),
-      },
-      this.realm
-    );
+    const transferResponse =
+      await this.client.ApiClient.postInvestecTransferMultiple(
+        this.client.token.access_token,
+        {
+          fromAccountId: this.accountId,
+          toAccounts: recipients.map((r) => ({
+            accountId: r.account.accountId,
+            amount: r.amount,
+            myReference: r.myReference,
+            theirReference: r.theirReference,
+          })),
+        },
+        this.realm
+      );
     if (isResponseBad(transferResponse)) {
       throw new Error(
         `not ok response while performing transfer for account: ${{
@@ -118,28 +114,31 @@ export class Account implements InvestecAccount {
     return transferResponse.data.TransferResponses;
   }
 
-  public async pay(recipients: Array<{
-    beneficiary: InvestecBeneficiary;
-    myReference: string;
-    theirReference: string;
-    amount: number;
-  }>): Promise<InvestecPayment[]> {
+  public async pay(
+    recipients: Array<{
+      beneficiary: InvestecBeneficiary;
+      myReference: string;
+      theirReference: string;
+      amount: number;
+    }>
+  ): Promise<InvestecPayment[]> {
     if (!this.client.token) {
       throw new Error("client is not set up");
     }
-    const transferResponse = await postInvestecPayMultiple(
-      this.client.token.access_token,
-      {
-        fromAccountId: this.accountId,
-        toBeneficiaries: recipients.map((r) => ({
-          beneficiaryId: r.beneficiary.beneficiaryId,
-          amount: r.amount,
-          myReference: r.myReference,
-          theirReference: r.theirReference,
-        })),
-      },
-      this.realm
-    );
+    const transferResponse =
+      await this.client.ApiClient.postInvestecPayMultiple(
+        this.client.token.access_token,
+        {
+          fromAccountId: this.accountId,
+          toBeneficiaries: recipients.map((r) => ({
+            beneficiaryId: r.beneficiary.beneficiaryId,
+            amount: r.amount,
+            myReference: r.myReference,
+            theirReference: r.theirReference,
+          })),
+        },
+        this.realm
+      );
     if (isResponseBad(transferResponse)) {
       throw new Error(
         `not ok response while performing transfer for account: ${{

--- a/lib/investec/Card.ts
+++ b/lib/investec/Card.ts
@@ -1,18 +1,5 @@
 import { Client } from "..";
 import {
-  getInvestecCardCountries,
-  getInvestecCardCurrencies,
-  getInvestecCardEnvironmentVariables,
-  getInvestecCardExecutions,
-  getInvestecCardMerchants,
-  getInvestecCardPublishedCode,
-  getInvestecCardSavedCode,
-  postInvestecCardEnvironmentVariables,
-  postInvestecCardPublishSavedCode,
-  postInvestecCardSaveCode,
-  postInvestecSimulateExecuteFunctionCode,
-} from "../util/investec";
-import {
   InvestecCard,
   InvestecCardCode,
   InvestecCardEnvironmentVariables,
@@ -29,7 +16,9 @@ export class Card implements InvestecCard {
     if (!client.token) {
       throw new Error("client is not set up");
     }
-    const response = await getInvestecCardCountries(client.token.access_token);
+    const response = await client.ApiClient.getInvestecCardCountries(
+      client.token.access_token
+    );
     if (isResponseBad(response)) {
       throw new Error(`error getting countries: ${{ response }}`);
     }
@@ -41,7 +30,9 @@ export class Card implements InvestecCard {
     if (!client.token) {
       throw new Error("client is not set up");
     }
-    const response = await getInvestecCardCurrencies(client.token.access_token);
+    const response = await client.ApiClient.getInvestecCardCurrencies(
+      client.token.access_token
+    );
     if (isResponseBad(response)) {
       throw new Error(`error getting countries: ${{ response }}`);
     }
@@ -53,7 +44,9 @@ export class Card implements InvestecCard {
     if (!client.token) {
       throw new Error("client is not set up");
     }
-    const response = await getInvestecCardMerchants(client.token.access_token);
+    const response = await client.ApiClient.getInvestecCardMerchants(
+      client.token.access_token
+    );
     if (isResponseBad(response)) {
       throw new Error(`error getting countries: ${{ response }}`);
     }
@@ -80,7 +73,7 @@ export class Card implements InvestecCard {
     if (!this.client.token) {
       throw new Error("client is not set up");
     }
-    const savedCode = await getInvestecCardSavedCode(
+    const savedCode = await this.client.ApiClient.getInvestecCardSavedCode(
       this.client.token.access_token,
       this.CardKey
     );
@@ -99,10 +92,11 @@ export class Card implements InvestecCard {
     if (!this.client.token) {
       throw new Error("client is not set up");
     }
-    const publishedCode = await getInvestecCardPublishedCode(
-      this.client.token.access_token,
-      this.CardKey
-    );
+    const publishedCode =
+      await this.client.ApiClient.getInvestecCardPublishedCode(
+        this.client.token.access_token,
+        this.CardKey
+      );
     if (isResponseBad(publishedCode)) {
       throw new Error(
         `not ok response while getting published code: ${{
@@ -119,7 +113,7 @@ export class Card implements InvestecCard {
       throw new Error("client is not set up");
     }
 
-    const savedCode = await postInvestecCardSaveCode(
+    const savedCode = await this.client.ApiClient.postInvestecCardSaveCode(
       this.client.token.access_token,
       this.CardKey,
       code
@@ -140,11 +134,12 @@ export class Card implements InvestecCard {
       throw new Error("client is not set up");
     }
 
-    const publishedCode = await postInvestecCardPublishSavedCode(
-      this.client.token.access_token,
-      this.CardKey,
-      codeId
-    );
+    const publishedCode =
+      await this.client.ApiClient.postInvestecCardPublishSavedCode(
+        this.client.token.access_token,
+        this.CardKey,
+        codeId
+      );
     if (isResponseBad(publishedCode)) {
       throw new Error(
         `not ok response while updating saved code: ${{
@@ -163,11 +158,12 @@ export class Card implements InvestecCard {
       throw new Error("client is not set up");
     }
 
-    const execution = await postInvestecSimulateExecuteFunctionCode(
-      this.client.token.access_token,
-      this.CardKey,
-      opts
-    );
+    const execution =
+      await this.client.ApiClient.postInvestecSimulateExecuteFunctionCode(
+        this.client.token.access_token,
+        this.CardKey,
+        opts
+      );
     if (isResponseBad(execution)) {
       throw new Error(
         `not ok response while updating saved code: ${{
@@ -184,7 +180,7 @@ export class Card implements InvestecCard {
       throw new Error("client is not set up");
     }
 
-    const execution = await getInvestecCardExecutions(
+    const execution = await this.client.ApiClient.getInvestecCardExecutions(
       this.client.token.access_token,
       this.CardKey
     );
@@ -204,10 +200,11 @@ export class Card implements InvestecCard {
       throw new Error("client is not set up");
     }
 
-    const execution = await getInvestecCardEnvironmentVariables(
-      this.client.token.access_token,
-      this.CardKey
-    );
+    const execution =
+      await this.client.ApiClient.getInvestecCardEnvironmentVariables(
+        this.client.token.access_token,
+        this.CardKey
+      );
     if (isResponseBad(execution)) {
       throw new Error(
         `not ok response while updating saved code: ${{
@@ -226,11 +223,12 @@ export class Card implements InvestecCard {
       throw new Error("client is not set up");
     }
 
-    const execution = await postInvestecCardEnvironmentVariables(
-      this.client.token.access_token,
-      this.CardKey,
-      variables
-    );
+    const execution =
+      await this.client.ApiClient.postInvestecCardEnvironmentVariables(
+        this.client.token.access_token,
+        this.CardKey,
+        variables
+      );
     if (isResponseBad(execution)) {
       throw new Error(
         `not ok response while updating saved code: ${{

--- a/lib/util/investec.ts
+++ b/lib/util/investec.ts
@@ -24,8 +24,6 @@ const RealmSelector: { [key in Realm]: "pb" | "bb" } = {
   private: "pb",
 };
 
-const INVESTEC_BASE_URL = "https://openapi.investec.com";
-
 const getBasicHeaders = (token: string) => {
   return {
     Authorization: `Bearer ${token}`,

--- a/lib/util/investec.ts
+++ b/lib/util/investec.ts
@@ -40,424 +40,439 @@ const safeResponse = <T>(response: Response) => {
   return response.json() as Promise<T>;
 };
 
-export const getInvestecToken = async (
-  clientId: string,
-  clientSecret: string,
-  apiKey: string
-): Promise<InvestecAuthResponse> => {
-  const tokenResponse = await fetch(
-    `${INVESTEC_BASE_URL}/identity/v2/oauth2/token`,
-    {
-      method: "POST",
-      body: `grant_type=client_credentials&scope=accounts`,
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: `Basic  ${Buffer.from(
-          `${clientId}:${clientSecret}`
-        ).toString("base64")} `,
+export const createInvestecAPIClient = (
+  baseUrl: string = "https://openapi.investec.com"
+) => {
+  const INVESTEC_BASE_URL = baseUrl;
+  return {
+    getInvestecToken: async (
+      clientId: string,
+      clientSecret: string,
+      apiKey: string
+    ): Promise<InvestecAuthResponse> => {
+      const tokenResponse = await fetch(
+        `${INVESTEC_BASE_URL}/identity/v2/oauth2/token`,
+        {
+          method: "POST",
+          body: `grant_type=client_credentials&scope=accounts`,
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: `Basic  ${Buffer.from(
+              `${clientId}:${clientSecret}`
+            ).toString("base64")} `,
 
-      "x-api-key": apiKey,
+            "x-api-key": apiKey,
+          },
+        }
+      );
+      return safeResponse<InvestecAuthResponse>(tokenResponse);
+    },
+
+    getInvestecOAuthToken: async (
+      clientId: string,
+      clientSecret: string,
+      apiKey: string,
+      authCode: string,
+      redirectUri: string
+    ): Promise<InvestecAuthResponse> => {
+      const tokenResponse = await fetch(
+        `${INVESTEC_BASE_URL}/identity/v2/oauth2/token`,
+        {
+          method: "POST",
+          body: `grant_type=authorization_code&code=${authCode}&redirect_uri=${redirectUri}`,
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: `Basic  ${Buffer.from(
+              `${clientId}:${clientSecret}`
+            ).toString("base64")} `,
+            "x-api-key": apiKey,
+          },
+        }
+      );
+      return safeResponse<InvestecAuthResponse>(tokenResponse);
+    },
+
+    refreshInvestecOAuthToken: async (
+      clientId: string,
+      clientSecret: string,
+      refreshToken: string
+    ): Promise<InvestecAuthResponse> => {
+      const tokenResponse = await fetch(
+        `${INVESTEC_BASE_URL}/identity/v2/oauth2/token`,
+        {
+          method: "POST",
+          body: `grant_type=refresh_token&refresh_token=${refreshToken}`,
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: `Basic  ${Buffer.from(
+              `${clientId}:${clientSecret}`
+            ).toString("base64")} `,
+          },
+        }
+      );
+      return safeResponse<InvestecAuthResponse>(tokenResponse);
+    },
+
+    getInvestecOAuthRedirectUrl: (
+      clientId: string,
+      scope: Scope[],
+      redirectUri: string
+    ): string => {
+      return `${INVESTEC_BASE_URL}/identity/v2/oauth2/authorize?scope=${scope.join(
+        " "
+      )}&client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+    },
+
+    getInvestecAccounts: async (
+      token: string,
+      realm: Realm = "private"
+    ): Promise<InvestecAccountsResponse> => {
+      const accountsResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecAccountsResponse>(accountsResponse);
+    },
+
+    getAccountBalance: async (
+      token: string,
+      accountId: string,
+      realm: Realm = "private"
+    ): Promise<InvestecAccountBalanceResponse> => {
+      const balanceResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts/${accountId}/balance`,
+        {
+          headers: { ...getBasicHeaders(token) },
+        }
+      );
+      return safeResponse<InvestecAccountBalanceResponse>(balanceResponse);
+    },
+
+    getInvestecTransactionsForAccount: async (
+      token: string,
+      {
+        accountId,
+        fromDate,
+        toDate,
+        transactionType,
+      }: {
+        accountId: string;
+        fromDate?: string;
+        toDate?: string;
+        transactionType?: InvestecTransactionTransactionType;
       },
-    }
-  );
-  return safeResponse<InvestecAuthResponse>(tokenResponse);
-};
+      realm: Realm = "private"
+    ): Promise<InvestecAccountTransactionsResponse> => {
+      const transactionsResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/${
+          RealmSelector[realm]
+        }/v1/accounts/${accountId}/transactions?${
+          fromDate ? ` &fromDate=${fromDate}` : ""
+        }${toDate ? `&toDate=${toDate}` : ""}
+        ${transactionType ? `&transactionType=${transactionType}` : ""}`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecAccountTransactionsResponse>(
+        transactionsResponse
+      );
+    },
 
-export const getInvestecOAuthToken = async (
-  clientId: string,
-  clientSecret: string,
-  apiKey: string,
-  authCode: string,
-  redirectUri: string
-): Promise<InvestecAuthResponse> => {
-  const tokenResponse = await fetch(
-    `${INVESTEC_BASE_URL}/identity/v2/oauth2/token`,
-    {
-      method: "POST",
-      body: `grant_type=authorization_code&code=${authCode}&redirect_uri=${redirectUri}`,
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: `Basic  ${Buffer.from(
-          `${clientId}:${clientSecret}`
-        ).toString("base64")} `,
-      "x-api-key": apiKey,
+    postInvestecTransferMultiple: async (
+      token: string,
+      {
+        fromAccountId,
+        toAccounts,
+      }: {
+        fromAccountId: string;
+        toAccounts: Array<{
+          accountId: string;
+          amount: number;
+          myReference: string;
+          theirReference: string;
+        }>;
       },
-    }
-  );
-  return safeResponse<InvestecAuthResponse>(tokenResponse);
-};
+      realm: Realm = "private"
+    ): Promise<InvestecAccountTransferResponse> => {
+      const body = {
+        transferList: toAccounts.map((t) => ({
+          beneficiaryAccountId: t.accountId,
+          amount: t.amount,
+          myReference: t.myReference,
+          theirReference: t.theirReference,
+        })),
+      };
+      const transferResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts/${fromAccountId}/transfermultiple`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecAccountTransferResponse>(transferResponse);
+    },
 
-export const refreshInvestecOAuthToken = async (
-  clientId: string,
-  clientSecret: string,
-  refreshToken: string
-): Promise<InvestecAuthResponse> => {
-  const tokenResponse = await fetch(
-    `${INVESTEC_BASE_URL}/identity/v2/oauth2/token`,
-    {
-      method: "POST",
-      body: `grant_type=refresh_token&refresh_token=${refreshToken}`,
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: `Basic  ${Buffer.from(
-          `${clientId}:${clientSecret}`
-        ).toString("base64")} `,
+    postInvestecPayMultiple: async (
+      token: string,
+      {
+        fromAccountId,
+        toBeneficiaries,
+      }: {
+        fromAccountId: string;
+        toBeneficiaries: Array<{
+          beneficiaryId: string;
+          amount: number;
+          myReference: string;
+          theirReference: string;
+        }>;
       },
-    }
-  );
-  return safeResponse<InvestecAuthResponse>(tokenResponse);
-};
+      realm: Realm = "private"
+    ): Promise<InvestecAccountPaymentResponse> => {
+      const body = {
+        paymentList: toBeneficiaries,
+      };
+      const transferResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts/${fromAccountId}/paymultiple`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecAccountPaymentResponse>(transferResponse);
+    },
 
-export const getInvestecOAuthRedirectUrl = (
-  clientId: string,
-  scope: Scope[],
-  redirectUri: string
-): string => {
-  return `${INVESTEC_BASE_URL}/identity/v2/oauth2/authorize?scope=${scope.join(
-    " "
-  )}&client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
-};
+    getInvestecBeneficiaries: async (token: string) => {
+      const beneficiariesResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/pb/v1/accounts/beneficiaries`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecBeneficiariesResponse>(beneficiariesResponse);
+    },
 
-export const getInvestecAccounts = async (
-  token: string,
-  realm: Realm = "private"
-): Promise<InvestecAccountsResponse> => {
-  const accountsResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecAccountsResponse>(accountsResponse);
-};
+    getInvestecBeneficiaryCategories: async (token: string) => {
+      const beneficiariesResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/pb/v1/accounts/beneficiarycategories`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecBeneficiaryCategoriesResponse>(
+        beneficiariesResponse
+      );
+    },
 
-export const getAccountBalance = async (
-  token: string,
-  accountId: string,
-  realm: Realm = "private"
-): Promise<InvestecAccountBalanceResponse> => {
-  const balanceResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts/${accountId}/balance`,
-    {
-      headers: { ...getBasicHeaders(token) },
-    }
-  );
-  return safeResponse<InvestecAccountBalanceResponse>(balanceResponse);
-};
+    getInvestecCards: async (token: string): Promise<InvestecCardsResponse> => {
+      const cardsResponse = await fetch(`${INVESTEC_BASE_URL}/za/v1/cards`, {
+        headers: {
+          ...getBasicHeaders(token),
+        },
+      });
+      return safeResponse<InvestecCardsResponse>(cardsResponse);
+    },
 
-export const getInvestecTransactionsForAccount = async (
-  token: string,
-  {
-    accountId,
-    fromDate,
-    toDate,
-    transactionType,
-  }: {
-    accountId: string;
-    fromDate?: string;
-    toDate?: string;
-    transactionType?: InvestecTransactionTransactionType;
-  },
-  realm: Realm = "private"
-): Promise<InvestecAccountTransactionsResponse> => {
-  const transactionsResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/${
-      RealmSelector[realm]
-    }/v1/accounts/${accountId}/transactions?${
-      fromDate ? ` &fromDate=${fromDate}` : ""
-    }${toDate ? `&toDate=${toDate}` : ""}
-      ${transactionType ? `&transactionType=${transactionType}` : ""}`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecAccountTransactionsResponse>(
-    transactionsResponse
-  );
-};
+    getInvestecCardSavedCode: async (
+      token: string,
+      cardKey: string
+    ): Promise<InvestecCardCodeResponse> => {
+      const cardsResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardCodeResponse>(cardsResponse);
+    },
 
-export const postInvestecTransferMultiple = async (
-  token: string,
-  {
-    fromAccountId,
-    toAccounts,
-  }: {
-    fromAccountId: string;
-    toAccounts: Array<{
-      accountId: string;
-      amount: number;
-      myReference: string;
-      theirReference: string;
-    }>;
-  },
-  realm: Realm = "private"
-): Promise<InvestecAccountTransferResponse> => {
-  const body = {
-    transferList: toAccounts.map((t) => ({
-      beneficiaryAccountId: t.accountId,
-      amount: t.amount,
-      myReference: t.myReference,
-      theirReference: t.theirReference,
-    })),
+    getInvestecCardPublishedCode: async (
+      token: string,
+      cardKey: string
+    ): Promise<InvestecCardCodeResponse> => {
+      const cardsResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/publishedcode`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardCodeResponse>(cardsResponse);
+    },
+
+    postInvestecCardSaveCode: async (
+      token: string,
+      cardKey: string,
+      code: string
+    ): Promise<InvestecCardCodeResponse> => {
+      const body = { code };
+      const response = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardCodeResponse>(response);
+    },
+
+    postInvestecCardPublishSavedCode: async (
+      token: string,
+      cardKey: string,
+      codeId: string
+    ): Promise<InvestecCardCodeResponse> => {
+      const body = { codeid: codeId, code: "" };
+      const response = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardCodeResponse>(response);
+    },
+
+    postInvestecSimulateExecuteFunctionCode: async (
+      token: string,
+      cardKey: string,
+      opts: InvestecSimulateExecutionInput
+    ): Promise<InvestecCardExecutionResponse> => {
+      const body = { ...opts };
+      const response = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code/execute`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardExecutionResponse>(response);
+    },
+
+    getInvestecCardExecutions: async (
+      token: string,
+      cardKey: string
+    ): Promise<InvestecCardExecutionResponse> => {
+      const cardsResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code/executions`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardExecutionResponse>(cardsResponse);
+    },
+
+    getInvestecCardEnvironmentVariables: async (
+      token: string,
+      cardKey: string
+    ): Promise<InvestecCardEnvironmentVariablesResponse> => {
+      const envResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/environmentvariables`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardEnvironmentVariablesResponse>(
+        envResponse
+      );
+    },
+
+    postInvestecCardEnvironmentVariables: async (
+      token: string,
+      cardKey: string,
+      variables: { [key in string]: string | number | boolean | Object }
+    ): Promise<InvestecCardEnvironmentVariablesResponse> => {
+      const body = { variables };
+      const response = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/environmentvariables`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+          headers: {
+            "Content-Type": "application/json",
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardEnvironmentVariablesResponse>(response);
+    },
+
+    getInvestecCardCountries: async (
+      token: string
+    ): Promise<InvestecCardNameCodeResponse> => {
+      const envResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/countries`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardNameCodeResponse>(envResponse);
+    },
+
+    getInvestecCardCurrencies: async (
+      token: string
+    ): Promise<InvestecCardNameCodeResponse> => {
+      const envResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/currencies`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardNameCodeResponse>(envResponse);
+    },
+
+    getInvestecCardMerchants: async (
+      token: string
+    ): Promise<InvestecCardNameCodeResponse> => {
+      const envResponse = await fetch(
+        `${INVESTEC_BASE_URL}/za/v1/cards/merchants`,
+        {
+          headers: {
+            ...getBasicHeaders(token),
+          },
+        }
+      );
+      return safeResponse<InvestecCardNameCodeResponse>(envResponse);
+    },
   };
-  const transferResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts/${fromAccountId}/transfermultiple`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecAccountTransferResponse>(transferResponse);
-};
-
-export const postInvestecPayMultiple = async (
-  token: string,
-  {
-    fromAccountId,
-    toBeneficiaries,
-  }: {
-    fromAccountId: string;
-    toBeneficiaries: Array<{
-      beneficiaryId: string;
-      amount: number;
-      myReference: string;
-      theirReference: string;
-    }>;
-  },
-  realm: Realm = "private"
-): Promise<InvestecAccountPaymentResponse> => {
-  const body = {
-    paymentList: toBeneficiaries
-  };
-  const transferResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/${RealmSelector[realm]}/v1/accounts/${fromAccountId}/paymultiple`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecAccountPaymentResponse>(transferResponse);
-};
-
-export const getInvestecBeneficiaries = async (token: string) => {
-  const beneficiariesResponse = await fetch(`${INVESTEC_BASE_URL}/za/pb/v1/accounts/beneficiaries`, {
-    headers: {
-      ...getBasicHeaders(token),
-    },
-  });
-  return safeResponse<InvestecBeneficiariesResponse>(beneficiariesResponse);
-}
-
-export const getInvestecBeneficiaryCategories = async (token: string) => {
-  const beneficiariesResponse = await fetch(`${INVESTEC_BASE_URL}/za/pb/v1/accounts/beneficiarycategories`, {
-    headers: {
-      ...getBasicHeaders(token),
-    },
-  });
-  return safeResponse<InvestecBeneficiaryCategoriesResponse>(beneficiariesResponse);
-}
-
-export const getInvestecCards = async (
-  token: string
-): Promise<InvestecCardsResponse> => {
-  const cardsResponse = await fetch(`${INVESTEC_BASE_URL}/za/v1/cards`, {
-    headers: {
-      ...getBasicHeaders(token),
-    },
-  });
-  return safeResponse<InvestecCardsResponse>(cardsResponse);
-};
-
-export const getInvestecCardSavedCode = async (
-  token: string,
-  cardKey: string
-): Promise<InvestecCardCodeResponse> => {
-  const cardsResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardCodeResponse>(cardsResponse);
-};
-
-export const getInvestecCardPublishedCode = async (
-  token: string,
-  cardKey: string
-): Promise<InvestecCardCodeResponse> => {
-  const cardsResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/publishedcode`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardCodeResponse>(cardsResponse);
-};
-
-export const postInvestecCardSaveCode = async (
-  token: string,
-  cardKey: string,
-  code: string
-): Promise<InvestecCardCodeResponse> => {
-  const body = { code };
-  const response = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardCodeResponse>(response);
-};
-
-export const postInvestecCardPublishSavedCode = async (
-  token: string,
-  cardKey: string,
-  codeId: string
-): Promise<InvestecCardCodeResponse> => {
-  const body = { codeid: codeId, code: "" };
-  const response = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardCodeResponse>(response);
-};
-
-export const postInvestecSimulateExecuteFunctionCode = async (
-  token: string,
-  cardKey: string,
-  opts: InvestecSimulateExecutionInput
-): Promise<InvestecCardExecutionResponse> => {
-  const body = { ...opts };
-  const response = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code/execute`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardExecutionResponse>(response);
-};
-
-export const getInvestecCardExecutions = async (
-  token: string,
-  cardKey: string
-): Promise<InvestecCardExecutionResponse> => {
-  const cardsResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/code/executions`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardExecutionResponse>(cardsResponse);
-};
-
-export const getInvestecCardEnvironmentVariables = async (
-  token: string,
-  cardKey: string
-): Promise<InvestecCardEnvironmentVariablesResponse> => {
-  const envResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/environmentvariables`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardEnvironmentVariablesResponse>(envResponse);
-};
-
-export const postInvestecCardEnvironmentVariables = async (
-  token: string,
-  cardKey: string,
-  variables: { [key in string]: string | number | boolean | Object }
-): Promise<InvestecCardEnvironmentVariablesResponse> => {
-  const body = { variables };
-  const response = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/${cardKey}/environmentvariables`,
-    {
-      method: "POST",
-      body: JSON.stringify(body),
-      headers: {
-        "Content-Type": "application/json",
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardEnvironmentVariablesResponse>(response);
-};
-
-export const getInvestecCardCountries = async (
-  token: string
-): Promise<InvestecCardNameCodeResponse> => {
-  const envResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/countries`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardNameCodeResponse>(envResponse);
-};
-
-export const getInvestecCardCurrencies = async (
-  token: string
-): Promise<InvestecCardNameCodeResponse> => {
-  const envResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/currencies`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardNameCodeResponse>(envResponse);
-};
-
-export const getInvestecCardMerchants = async (
-  token: string
-): Promise<InvestecCardNameCodeResponse> => {
-  const envResponse = await fetch(
-    `${INVESTEC_BASE_URL}/za/v1/cards/merchants`,
-    {
-      headers: {
-        ...getBasicHeaders(token),
-      },
-    }
-  );
-  return safeResponse<InvestecCardNameCodeResponse>(envResponse);
 };


### PR DESCRIPTION
Seeing as there exists a sandbox environment as well as enabling local development, the URL that is used to interact with the Investec API should be configurable.

The URL can now be configured when calling `Client.create` by passing the desired URL as the last parameter.

Related conversations:
- [Feature Request](https://investec-dev-com.slack.com/archives/C05MFMYUPE2/p1722587700880179)
- [Slack convo](https://investec-dev-com.slack.com/archives/C05MQQDUJ3E/p1723788061067839)
- Supersedes #7 